### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
 
 # install Spark
 RUN mkdir -p /opt/graphsense && \
-    wget https://www.apache.org/dist/spark/spark-2.4.7/spark-2.4.7-bin-without-hadoop-scala-2.12.tgz -O - | tar -xz -C /opt && \
-    ln -s /opt/spark-2.4.7-bin-without-hadoop-scala-2.12 /opt/spark && \
+    wget https://www.apache.org/dist/spark/spark-2.4.8/spark-2.4.8-bin-without-hadoop-scala-2.12.tgz -O - | tar -xz -C /opt && \
+    ln -s /opt/spark-2.4.8-bin-without-hadoop-scala-2.12 /opt/spark && \
     wget https://archive.apache.org/dist/hadoop/core/hadoop-2.7.7/hadoop-2.7.7.tar.gz -O - | tar -xz -C /opt && \
     ln -s /opt/hadoop-2.7.7 /opt/hadoop && \
     echo "#!/usr/bin/env bash\nexport SPARK_DIST_CLASSPATH=$(/opt/hadoop/bin/hadoop classpath)" >> /opt/spark/conf/spark-env.sh && \


### PR DESCRIPTION
The latest 2.x version of Spark is 2.4.8, older versions are not supported anymore. If 2.4.7 should be downloaded then the URL changed to Apache archive: https://archive.apache.org/dist/spark/spark-2.4.7/spark-2.4.7-bin-without-hadoop-scala-2.12.tgz